### PR TITLE
TMRG cmake function udpate

### DIFF
--- a/cmake/tmrg/tmrg/tmrg.cmake
+++ b/cmake/tmrg/tmrg/tmrg.cmake
@@ -153,6 +153,10 @@ function(tmrg IP_LIB)
         set(TMRG_COMMAND ${TMRG_COMMAND} --no-common-definitions)
     endif()
 
+    if(NOT ARG_HEADER)
+        set(TMRG_COMMAND ${TMRG_COMMAND} --no-header)
+    endif()
+
     # To avoid replacing unwanted 'wor' character sequence, assume real wor (i.e., wired-or)
     # sequence is always followed by a space. Otherwise, if 'wor' is used in a name (e.g., word_address)
     # it will also be replaced (e.g., to wird_address).
@@ -165,7 +169,7 @@ function(tmrg IP_LIB)
         OUTPUT ${TRMG_GEN} ${STAMP_FILE}
         COMMAND ${TMRG_COMMAND}
         ${SED_COMMAND}
-        COMMAND touch ${STAMP_FILE}
+        COMMAND /bin/sh -c date > ${STAMP_FILE}
         DEPENDS ${IP_TMRG_SRC} ${SCR_DEPS_STRIPPED}
         COMMENT "Running ${CMAKE_CURRENT_FUNCTION} on ${IP_LIB}"
     )


### PR DESCRIPTION
TMRG cmake function updated with:

1. by default the --no-header option is used unless the HEADER argument is passed
2. To keep the header timestamp (to have a simple way to check when were generated the triplicate files) the date and time is added to the stamp file content.

This way, tracking triplicated files and checking for changes is simpler (otherwise files always change because of the different time). It also enable sanity check using CI to see if files copied using the copy_rtl cmake function have been manually modified.