### PR TITLE
Relative path to file list for user portability.

### DIFF
--- a/cmake/utils/copy_rtl_files/copy_rtl_files.py
+++ b/cmake/utils/copy_rtl_files/copy_rtl_files.py
@@ -60,8 +60,10 @@ def main():
 
     # Write copied files list to outdir
     with open(os.path.join(args.outdir, 'rtl_sources.f'), 'w') as outfile:
-        for i in copied_src:
-            outfile.write(f'{i}\n')
+        for file_path in copied_src:
+            # Keep only the relative path to not be used dependent
+            rel_file_path = os.path.relpath(file_path, args.outdir)
+            outfile.write(f'{rel_file_path}\n')
 
     # Get the includes list from vhier
     try:


### PR DESCRIPTION
Closes #37.

To make the copy RTL function more portable, the generated list of files is now listing relative path from the output directory where the files are copied and the list of files is created.