### PR TITLE
added sed_wor option to verilate function

### DIFF
--- a/cmake/sim/verilator/verilate.cmake
+++ b/cmake/sim/verilator/verilate.cmake
@@ -1,5 +1,5 @@
 function(verilate IP_LIB)
-    set(OPTIONS "COVERAGE;TRACE;TRACE_FST;SYSTEMC;TRACE_STRUCTS;MAIN")
+    set(OPTIONS "COVERAGE;TRACE;TRACE_FST;SYSTEMC;TRACE_STRUCTS;SED_WOR;MAIN")
     set(ONE_PARAM_ARGS "PREFIX;TOP_MODULE;THREADS;TRACE_THREADS;DIRECTORY;EXECUTABLE_NAME")
     set(MULTI_PARAM_ARGS "VERILATOR_ARGS;OPT_SLOW;OPT_FAST;OPT_GLOBAL")
 
@@ -71,6 +71,53 @@ function(verilate IP_LIB)
     endforeach()
 
     get_ip_rtl_sources(SOURCES ${IP_LIB})
+    
+    # String replace "wor " with "wire " in TMR files, since Verilator does not support "wor"
+    # TODO: Remove this if Verilator ever supports "wor"
+    if(ARG_SED_WOR)
+        file(MAKE_DIRECTORY ${BINARY_DIR}/sed_wor)
+        set(MODIFIED_SOURCES "")
+
+        foreach(source ${SOURCES})
+            get_filename_component(source_name ${source} NAME)
+            if(source_name MATCHES "TMR")
+                set(output_file "${BINARY_DIR}/sed_wor/${source_name}")
+                list(APPEND MODIFIED_SOURCES ${output_file}) 
+
+                add_custom_command(
+                    OUTPUT ${output_file}
+                    COMMAND sed "s/wor /wire /g" ${source} > ${output_file}
+                    DEPENDS ${source}
+                    COMMENT "Replacing wor with wire in ${source_name}."
+                )
+            else()
+                list(APPEND MODIFIED_SOURCES ${source})
+            endif()
+        endforeach()
+
+        # Update sources to use modified sources
+        set(SOURCES ${MODIFIED_SOURCES})
+
+        # Create stamp file for sed command
+        set(STAMP_FILE "${BINARY_DIR}/sed_wor/${IP_LIB}_sed_wor.stamp")
+
+        add_custom_command(
+            OUTPUT ${STAMP_FILE}
+            COMMAND /bin/sh -c date > ${STAMP_FILE}
+            DEPENDS ${MODIFIED_SOURCES}
+            COMMENT "Generating stamp file after sed commands."
+        )
+
+        add_custom_target(
+            ${IP_LIB}_sed_wor ALL 
+            DEPENDS  ${STAMP_FILE}
+        )
+
+        add_dependencies(${IP_LIB} ${IP_LIB}_sed_wor)
+        # unset, so argument is not further passed to verilator bin
+        unset(ARG_SED_WOR)
+    endif()
+
     get_ip_sim_only_sources(SIM_SOURCES ${IP_LIB})
     list(PREPEND SOURCES ${SIM_SOURCES})
 
@@ -172,6 +219,11 @@ function(verilate IP_LIB)
 
     set(VLT_STATIC_LIB "${DIRECTORY}/lib${ARG_TOP_MODULE}.a")
     set(INC_DIR ${DIRECTORY})
+
+    # TODO: Remove this if Verilator ever supports "wor"
+    if(TARGET ${IP_LIB}__sed_wor)
+        add_dependencies(${VERILATE_TARGET} ${IP_LIB}__sed_wor)
+    endif()
 
     set(VERILATED_LIB ${IP_LIB}__vlt)
     add_library(${VERILATED_LIB} STATIC IMPORTED)


### PR DESCRIPTION
Verilator does not support `wor` added by TMRG. However, `wor`, is needed by implementation to infer OR trees for voter error signals. So instead of doing a string replace on the source files (which are also used in `impl` ) after each tmrg call, we now do it only on the sources passed to verilator.

Remove this if verilator supports wor in the future, (see https://github.com/verilator/verilator/issues/5386). 