### PR TITLE
allow add_ip short form, resolves #42

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,5 @@
-
 add_custom_target(check
-    COMMAND ctest
+    COMMAND ctest $(JOBS)
     )
 
 add_subdirectory(iverilog)

--- a/tests/add_ip/add_ip.cmake
+++ b/tests/add_ip/add_ip.cmake
@@ -4,6 +4,7 @@ set(TEST_NAME add_ip)
 
 ct_add_test(NAME ${TEST_NAME})
 function(${${TEST_NAME}})
+    ## Test full add_ip() call
     add_ip(ip
         VENDOR vendor
         LIBRARY lib
@@ -18,4 +19,24 @@ function(${${TEST_NAME}})
     ct_assert_equal(IP_LIBRARY "lib")
     ct_assert_equal(IP_VERSION "1.2.3")
     ct_assert_target_exists(${IP_VENDOR}__${IP_LIBRARY}__${IP_NAME}__${IP_VERSION})
+
+    add_ip(ip4
+        VERSION 1.1.1
+        )
+    ct_assert_target_exists(ip4::1.1.1)
+    ct_assert_target_exists(ip4__1.1.1)
+
+    ## Test shortened add_ip() call 
+    add_ip(vendor2::lib2::ip2::1.2.2)
+
+    ct_assert_target_exists(vendor2::lib2::ip2::1.2.2)
+    ct_assert_target_exists(vendor2__lib2__ip2__1.2.2)
+
+    ct_assert_equal(IP vendor2__lib2__ip2__1.2.2)
+    ct_assert_equal(IP_NAME "ip2")
+    ct_assert_equal(IP_VENDOR "vendor2")
+    ct_assert_equal(IP_LIBRARY "lib2")
+    ct_assert_equal(IP_VERSION "1.2.2")
+    ct_assert_target_exists(${IP_VENDOR}__${IP_LIBRARY}__${IP_NAME}__${IP_VERSION})
+
 endfunction()

--- a/tests/add_ip/add_ip_1_token.cmake
+++ b/tests/add_ip/add_ip_1_token.cmake
@@ -1,0 +1,32 @@
+# This test will succed because its allowed to have short notation in `ip_link(ip)` call
+include("${CMAKE_CURRENT_LIST_DIR}/../../CMakeLists.txt")
+
+set(TEST_NAME add_ip_1_token)
+
+ct_add_test(NAME ${TEST_NAME})
+function(${${TEST_NAME}})
+    add_ip(vendor::lib::ip1::0.0.1)
+    ct_assert_target_exists(vendor::lib::ip1::0.0.1)
+    ct_assert_target_exists(vendor__lib__ip1__0.0.1)
+    ct_assert_equal(IP vendor__lib__ip1__0.0.1)
+    ct_assert_equal(IP_VENDOR vendor)
+    ct_assert_equal(IP_LIBRARY lib)
+    ct_assert_equal(IP_VERSION 0.0.1)
+
+    add_ip(ip2
+        VENDOR vendor
+        LIBRARY lib
+        )
+    ct_assert_target_exists(vendor::lib::ip2)
+    ct_assert_equal(IP vendor__lib__ip2)
+    ct_assert_equal(IP_VENDOR vendor)
+    ct_assert_equal(IP_LIBRARY lib)
+    ct_assert_not_defined(IP_VERSION)
+
+    add_ip(ip3)
+    ct_assert_target_exists(ip3)
+    ct_assert_equal(IP ip3)
+    ct_assert_not_defined(IP_VENDOR)
+    ct_assert_not_defined(IP_LIBRARY)
+    ct_assert_not_defined(IP_VERSION)
+endfunction()

--- a/tests/add_ip/add_ip_fail_2_tokens.cmake
+++ b/tests/add_ip/add_ip_fail_2_tokens.cmake
@@ -1,0 +1,45 @@
+# This tests should fail because its not allowed to have different than 4 or 1 tokens in `ip_link()` call
+include("${CMAKE_CURRENT_LIST_DIR}/../../CMakeLists.txt")
+
+set(TEST_NAME add_ip_fail_2_tokens_name_version)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(ip1::0.0.1)
+endfunction()
+
+set(TEST_NAME add_ip_fail_2_tokens_vendor_name)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::ip1)
+endfunction()
+
+set(TEST_NAME add_ip_fail_2_tokens_vendor_lib)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::lib)
+endfunction()
+
+set(TEST_NAME add_ip_fail_2_tokens_vendor_version)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::0.0.1)
+endfunction()
+
+set(TEST_NAME add_ip_fail_2_tokens_lib_version)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(lib::0.0.1)
+endfunction()
+
+
+set(TEST_NAME add_ip_fail_2_tokens_empty_token_1)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(lib::)
+endfunction()
+
+set(TEST_NAME add_ip_fail_2_tokens_empty_token_2)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(::lib)
+endfunction()

--- a/tests/add_ip/add_ip_fail_3_tokens.cmake
+++ b/tests/add_ip/add_ip_fail_3_tokens.cmake
@@ -1,0 +1,51 @@
+# This tests should fail because its not allowed to have different than 4 or 1 tokens in `ip_link()` call
+include("${CMAKE_CURRENT_LIST_DIR}/../../CMakeLists.txt")
+
+set(TEST_NAME add_ip_fail_3_tokens_vendor_lib_ip)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::lib::ip)
+endfunction()
+
+set(TEST_NAME add_ip_fail_3_tokens_vendor_lib_version)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::lib::0.0.1)
+endfunction()
+
+set(TEST_NAME add_ip_fail_3_tokens_lib_ip_version)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(lib::ip::0.0.1)
+endfunction()
+
+set(TEST_NAME add_ip_fail_3_tokens_empty_token_1)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(::::vendor)
+endfunction()
+
+set(TEST_NAME add_ip_fail_3_tokens_empty_token_2)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(::vendor::lib)
+endfunction()
+
+set(TEST_NAME add_ip_fail_3_tokens_empty_token_3)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::::lib)
+endfunction()
+
+set(TEST_NAME add_ip_fail_3_tokens_empty_token_4)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::lib::)
+endfunction()
+
+set(TEST_NAME add_ip_fail_3_tokens_empty_token_5)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::::)
+endfunction()
+

--- a/tests/add_ip/add_ip_fail_4_tokens.cmake
+++ b/tests/add_ip/add_ip_fail_4_tokens.cmake
@@ -1,0 +1,34 @@
+# This tests should fail because its not allowed to have different than 4 or 1 tokens in `ip_link()` call
+include("${CMAKE_CURRENT_LIST_DIR}/../../CMakeLists.txt")
+
+set(TEST_NAME add_ip_fail_4_tokens_empty_token_1)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(::::::vendor)
+endfunction()
+
+set(TEST_NAME add_ip_fail_4_tokens_empty_token_2)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(::::vendor::)
+endfunction()
+
+set(TEST_NAME add_ip_fail_4_tokens_empty_token_3)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(::vendor::lib::)
+endfunction()
+
+set(TEST_NAME add_ip_fail_4_tokens_empty_token_4)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::lib::::0.0.1)
+endfunction()
+
+set(TEST_NAME add_ip_fail_4_tokens_empty_token_5)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::lib::ip::)
+endfunction()
+
+

--- a/tests/add_ip/add_ip_fail_too_many_tokens.cmake
+++ b/tests/add_ip/add_ip_fail_too_many_tokens.cmake
@@ -1,0 +1,20 @@
+# This tests should fail because its not allowed to have different than 4 or 1 tokens in `ip_link()` call
+include("${CMAKE_CURRENT_LIST_DIR}/../../CMakeLists.txt")
+
+set(TEST_NAME add_ip_fail_5_tokens)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::lib::ip::0.0.1::token)
+endfunction()
+
+set(TEST_NAME add_ip_fail_6_tokens)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::lib::ip::0.0.1::token1::token2)
+endfunction()
+
+set(TEST_NAME add_ip_fail_7_tokens)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(vendor::lib::ip::0.0.1::token1::token2::token3)
+endfunction()

--- a/tests/ip_link/ip_link_self_link_fatal.cmake
+++ b/tests/ip_link/ip_link_self_link_fatal.cmake
@@ -1,3 +1,4 @@
+# This test is expected to throw FATAL_ERROR because `ip_link()` links ip1 to itself
 include("${CMAKE_CURRENT_LIST_DIR}/../../CMakeLists.txt")
 
 set(TEST_NAME ip_link_self_link_fatal)

--- a/tests/peakrdl/print/CMakeLists.txt
+++ b/tests/peakrdl/print/CMakeLists.txt
@@ -87,3 +87,4 @@ add_test(NAME ${PROJECT_NAME}
     COMMAND /bin/bash -c "diff <(make ${IP}_peakrdl_print | sed -e 's/\\x1b\[[0-9;]*m//g') <(cat  ${CMAKE_CURRENT_LIST_DIR}/golden.txt)"
     # Diff with golden, and ignore colours in make output with sed command
     )
+set_property(TEST ${PROJECT_NAME} PROPERTY LABELS peakrdl)


### PR DESCRIPTION
This pull request implements the short signature for `add_ip()` function.

Now there are 3 versions:

## 1. Full form
```
add_ip(ip
    VENDOR vendor
    LIBRARY lib
    VERSION 0.0.1
)
```
This translates into `vendor::lib::ip::0.0.1` target

In this version, it is possible to omit any of the VENDOR, LIBRARY, VERSION arguments.
A special case of full form is when all of them are omitted.
```
add_ip(ip)
```
This translates into `ip` target

## 2. Short form

In the short form the VLNV format can be passed to `add_ip()`.
Like this:
```add_ip(vendor::lib::ip::0.0.1)```

In this form it is important that the full form is passed, as if one of the tokens are missing, how can we know what is VENDOR, LIBRARY, IP, VERSION
