### PR TITLE
xcelium function never fetching sim_only files fixed

### DIFF
--- a/cmake/sim/cadence/xcelium.cmake
+++ b/cmake/sim/cadence/xcelium.cmake
@@ -12,6 +12,8 @@
 # :type ELABORATE: string
 # :keyword UNIQUIFY: Uniquifies the list of ip sources based on the basename of the files.
 # :type UNIQUIFY: string
+# :keyword SYNTHESIS: Prevents behavioural/generic RTL files to be fetched.
+# :type SYNTHESIS: string
 # :keyword ACCESS: Access rights (i.e., visibility) used to compile and elaborate the design. For debugging pass 'rwc'.
 # :type ACCESS: string
 # :keyword SETENV: List of env variables passed to xrun.
@@ -22,7 +24,7 @@
 # :type ARGS: string
 #]]
 function(xcelium IP_LIB)
-    cmake_parse_arguments(ARG "ELABORATE;UNIQUIFY" "ACCESS" "SETENV;DEFINES;ARGS" ${ARGN})
+    cmake_parse_arguments(ARG "ELABORATE;UNIQUIFY;SYNTHESIS" "ACCESS" "SETENV;DEFINES;ARGS" ${ARGN})
     if(ARG_UNPARSED_ARGUMENTS)
         message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} passed unrecognized argument " "${ARG_UNPARSED_ARGUMENTS}")
     endif()
@@ -35,6 +37,10 @@ function(xcelium IP_LIB)
 
     # Get RTL and TB sources
     get_ip_rtl_sources(SOURCES_LIST ${IP_LIB})
+    if(NOT ${ARG_SYNTHESIS})
+        get_ip_sim_only_sources(SIM_SOURCES_LIST ${IP_LIB})
+        list(PREPEND SOURCES_LIST ${SIM_SOURCES_LIST})
+    endif()
     get_ip_tb_only_rtl_sources(TB_SOURCES_LIST ${IP_LIB})
     list(APPEND SOURCES_LIST ${TB_SOURCES_LIST})
 

--- a/cmake/tmrg/tmrg/tmrg.cmake
+++ b/cmake/tmrg/tmrg/tmrg.cmake
@@ -208,8 +208,10 @@ function(tmrg IP_LIB)
     # Add dependency to the IP
     add_dependencies(${IP_LIB} ${IP_LIB}_${CMAKE_CURRENT_FUNCTION})
 
-    # Get the existing linked libraries
-    safe_get_target_property(LINKED_IP ${IP_LIB} INTERFACE_LINK_LIBRARIES "")
+    # Get recursively linked libraries to link to any <>_tmrg target
+    # If no recusrive search is done, the dependency is broken as soon as one level
+    # does not have any tmrg target
+    recursive_get_target_property(LINKED_IP ${IP_LIB} INTERFACE_LINK_LIBRARIES "")
     # Trigger the dependencies tmrg targets if they exist
     message(DEBUG "TMRG: checking linked libraries for IP ${IP_LIB}")
     foreach(linked_lib ${LINKED_IP})


### PR DESCRIPTION
### Changes
 - xce;lium function: Added synthesis keyword do disable RTL sim_only files to be fetched to provide flexibility to the user.
 - tmrg.cmake: recursive search of target property function added. This is done for tmrg funciton in particular (INTERFACE_LINK_LIBRARIES property) to add a dependency to linked IPs <ip>_tmrg targets to properly trigger the TMR files generation (know the dependency is broken if no directly linked ips have a tmrg target but the linked ips of the linked ones have).
 - recursive_get_target_property: this function could replace the flatten_graph function as a more understandable/readable solution but advanced tests have been done to check it can achieve similar results.