### PR TITLE
Version conditions for ip_link()

### DIFF
--- a/cmake/hwip.cmake
+++ b/cmake/hwip.cmake
@@ -418,6 +418,58 @@ function(check_languages LANGUAGE)
     endif()
 endfunction()
 
+
+function(__compare_version RESULT COMPARE_LHS RELATION COMPARE_RHS)
+
+    if(RELATION STREQUAL ">=")
+        set(RELATION VERSION_GREATER_EQUAL)
+    elseif(RELATION STREQUAL ">")
+        set(RELATION VERSION_GREATER)
+    elseif(RELATION STREQUAL "<=")
+        set(RELATION VERSION_LESS_EQUAL)
+    elseif(RELATION STREQUAL "<")
+        set(RELATION VERSION_LESS)
+    elseif(RELATION STREQUAL "==")
+        set(RELATION VERSION_EQUAL)
+    endif()
+
+    if(${COMPARE_LHS} ${RELATION} ${COMPARE_RHS})
+        set(${RESULT} TRUE PARENT_SCOPE)
+    else()
+        set(${RESULT} FALSE PARENT_SCOPE)
+    endif()
+endfunction()
+
+function(__ip_link_check_version OUT_IP_WO_VERSION IP_LIB)
+    string(REPLACE " " "" ip_lib_str "${IP_LIB}")
+    string(REGEX MATCHALL "(>=|<=|==|<|>)([0-9]+\.[0-9]+\.[0-9])" version_ranges "${ip_lib_str}")
+
+    # If regex did not match, there is no comparison string in the linked IP, so just exit
+    if(NOT version_ranges)
+        set(${OUT_IP_WO_VERSION} ${IP_LIB} PARENT_SCOPE)
+        return()
+    endif()
+
+    # extract the VLN from "v::l::ip2>= 1.0.0,<=2.0.0" by getting a substring until first regex match
+    list(GET version_ranges 0 first_range_idx)
+    string(FIND "${ip_lib_str}" "${first_range_idx}" first_found)
+    string(SUBSTRING "${ip_lib_str}" 0 ${first_found} ip_lib_wo_version)
+    set(${OUT_IP_WO_VERSION} ${ip_lib_wo_version} PARENT_SCOPE)
+
+    get_target_property(ip_version ${ip_lib_wo_version} VERSION)
+
+    set(version_satisfied TRUE)
+    foreach(version_range ${version_ranges})
+        string(REGEX MATCH "(>=|<=|==|<|>)([0-9]+\.[0-9]+\.[0-9])" version_ranges "${version_range}")
+
+        __compare_version(satisfies "${ip_version}" "${CMAKE_MATCH_1}" "${CMAKE_MATCH_2}")
+        if(NOT satisfies)
+            set(version_satisfied FALSE)
+            message(FATAL_ERROR "Linked IP \"${ip_lib_wo_version}\" version condition \"${ip_version} ${CMAKE_MATCH_1} ${CMAKE_MATCH_2}\" cannot be satisfied")
+        endif()
+    endforeach()
+endfunction()
+
 #[[[
 # This function adds a target link library and a dependency to an IP target.
 #
@@ -425,6 +477,14 @@ endfunction()
 # if the link library exists and adds it (if it's not already added). Finally, the link library is added
 # as a dependency. This last step can be skipped with the keyword NODEPEND. The dependencies are passed
 # as a list after the parameters and the keyword.
+#
+# It is also allowed to pass version conditions to be checked as following:
+#  ```
+# ip_link(v::l::ip1::1.1.1
+#     "v::l::ip2 >= 1.0.4, <=2.0.0")
+#  ```
+# If all the comparisons are not satisfied, FATAL_ERROR is issued.
+# Allowed comparisons are ==, >=, >, <=, <
 #
 # :param IP_LIB: The target IP library name.
 # :type IP_LIB: string
@@ -455,6 +515,11 @@ function(ip_link IP_LIB)
         if(${lib} IN_LIST ALREADY_LINKED)
             continue()
         endif()
+
+        # Check the version conditions if present.
+        # Also remove the version conditions from the ${lib} string and keep only IP library VLN
+        __ip_link_check_version(lib ${lib})
+
         # Issue an error if the library does not exist
         if(NOT TARGET ${lib})
             message(FATAL_ERROR "Library ${lib} linked to ${_reallib} is not defined")

--- a/tests/tests/ip_link/ip_link_version_condition.cmake
+++ b/tests/tests/ip_link/ip_link_version_condition.cmake
@@ -2,24 +2,22 @@ include("${CMAKE_CURRENT_LIST_DIR}/../../../CMakeLists.txt")
 set(CDIR ${CMAKE_CURRENT_LIST_DIR})
 
 set(TEST_NAME ip_link_version_condition_0)
-
 ct_add_test(NAME ${TEST_NAME})
 function(${${TEST_NAME}})
     add_ip(v::l::top::1.5.1)
     add_ip(v::l::ip2::3.9.2)
-    add_ip(v::l::ip3::4.40.100)
-    add_ip(v::l::ip4::100.120.5)
+    add_ip(v::l::ip32::4.40.100)
+    add_ip(v::l::ip42::100.120.5)
 
 
     ip_link(v::l::top
             v::l::ip2::3.9.2
-            v::l::ip3::4.40.100
-            v::l::ip4::100.120.5
+            v::l::ip32::4.40.100
+            v::l::ip42::100.120.5
         )
 endfunction()
 
 set(TEST_NAME ip_link_version_condition_1)
-
 ct_add_test(NAME ${TEST_NAME})
 function(${${TEST_NAME}})
     add_ip(v::l::top::1.5.1)
@@ -58,7 +56,6 @@ endfunction()
 
 
 set(TEST_NAME ip_link_version_condition_mult_0)
-
 ct_add_test(NAME ${TEST_NAME})
 function(${${TEST_NAME}})
     add_ip(v::l::top::1.5.1)
@@ -70,19 +67,18 @@ function(${${TEST_NAME}})
 endfunction()
 
 set(TEST_NAME ip_link_version_condition_mult_1)
-
 ct_add_test(NAME ${TEST_NAME})
 function(${${TEST_NAME}})
     add_ip(v::l::top::1.5.1)
     add_ip(v::l::ip2::3.9.2)
-    add_ip(v::l::ip3::4.40.100)
-    add_ip(v::l::ip4::100.120.5)
+    add_ip(v::l::ip23::4.40.100)
+    add_ip(v::l::ip24::100.120.5)
 
 
     ip_link(v::l::top
             "v::l::ip2 >=3.9.0, <= 3.9.5"
-            "v::l::ip3 >= 4.0.100, < 4.100.0"
-            "v::l::ip4 < 200.200.200, > 100.100.100"
+            "v::l::ip23 >= 4.0.100, < 4.100.0"
+            "v::l::ip24 < 200.200.200, > 100.100.100"
         )
 endfunction()
 
@@ -221,4 +217,77 @@ function(${${TEST_NAME}})
     add_ip(v::l::top::1.5.1)
     add_ip(v::l::ip2::3.9.2)
     ip_link(v::l::top "v::l::ip2 > 3.9.2, < 4.9.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_mult_fail_2)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 > 3.9.1, != 3.9.2")
+endfunction()
+
+
+set(TEST_NAME ip_link_version_condition_neq_fail_1)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 != 3.9.2")
+endfunction()
+
+
+set(TEST_NAME ip_link_version_condition_neq_1)
+ct_add_test(NAME ${TEST_NAME})
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 != 3.9.1")
+    ip_link(v::l::top "v::l::ip2 != 3.9.20")
+    ip_link(v::l::top "v::l::ip2 != 3.10.2")
+    ip_link(v::l::top "v::l::ip2 != 3.8.2")
+    ip_link(v::l::top "v::l::ip2 != 4.9.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_maj_min_0)
+ct_add_test(NAME ${TEST_NAME})
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip3::3.9)
+    ip_link(v::l::top "v::l::ip3 != 3.8")
+    ip_link(v::l::top "v::l::ip3 >= 3.8")
+    ip_link(v::l::top "v::l::ip3 >  3.8")
+    ip_link(v::l::top "v::l::ip3 >  3.8")
+    ip_link(v::l::top "v::l::ip3 <  3.10")
+    ip_link(v::l::top "v::l::ip3 <= 3.10")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_mult_maj_min_0)
+ct_add_test(NAME ${TEST_NAME})
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip3::3.9)
+    ip_link(v::l::top "v::l::ip3 != 3.8, != 3.10")
+    ip_link(v::l::top "v::l::ip3 >= 3.0.1,  < 4.10")
+    ip_link(v::l::top "v::l::ip3 >  3.8, == 3.9")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_maj)
+ct_add_test(NAME ${TEST_NAME})
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip4::3)
+    ip_link(v::l::top "v::l::ip4 == 3")
+    ip_link(v::l::top "v::l::ip4 >= 2")
+    ip_link(v::l::top "v::l::ip4 <= 4")
+    ip_link(v::l::top "v::l::ip4 != 2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_mult_maj)
+ct_add_test(NAME ${TEST_NAME})
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip4::3)
+    ip_link(v::l::top "v::l::ip4 >= 2, <= 3")
+    ip_link(v::l::top "v::l::ip4 <= 4, >= 3 ")
 endfunction()

--- a/tests/tests/ip_link/ip_link_version_condition.cmake
+++ b/tests/tests/ip_link/ip_link_version_condition.cmake
@@ -1,0 +1,224 @@
+include("${CMAKE_CURRENT_LIST_DIR}/../../../CMakeLists.txt")
+set(CDIR ${CMAKE_CURRENT_LIST_DIR})
+
+set(TEST_NAME ip_link_version_condition_0)
+
+ct_add_test(NAME ${TEST_NAME})
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    add_ip(v::l::ip3::4.40.100)
+    add_ip(v::l::ip4::100.120.5)
+
+
+    ip_link(v::l::top
+            v::l::ip2::3.9.2
+            v::l::ip3::4.40.100
+            v::l::ip4::100.120.5
+        )
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_1)
+
+ct_add_test(NAME ${TEST_NAME})
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+
+
+    ip_link(v::l::top "v::l::ip2 >= 3.9.2")
+    ip_link(v::l::top "v::l::ip2 >  3.9.1")
+    ip_link(v::l::top "v::l::ip2 >  3.9.1")
+    ip_link(v::l::top "v::l::ip2 <  3.9.3")
+    ip_link(v::l::top "v::l::ip2 <= 3.9.3")
+    ip_link(v::l::top "v::l::ip2 <= 3.9.2")
+    ip_link(v::l::top "v::l::ip2 == 3.9.2")
+
+    ip_link(v::l::top "v::l::ip2 >= 3.8.2")
+    ip_link(v::l::top "v::l::ip2 >  3.8.1")
+    ip_link(v::l::top "v::l::ip2 >  3.8.1")
+    ip_link(v::l::top "v::l::ip2 <  3.10.3")
+    ip_link(v::l::top "v::l::ip2 <= 3.10.3")
+    ip_link(v::l::top "v::l::ip2 <= 3.10.2")
+
+    ip_link(v::l::top "v::l::ip2 >= 3.8.3")
+    ip_link(v::l::top "v::l::ip2 >  3.8.2")
+    ip_link(v::l::top "v::l::ip2 >  3.8.2")
+    ip_link(v::l::top "v::l::ip2 <  3.10.2")
+    ip_link(v::l::top "v::l::ip2 <= 3.10.2")
+    ip_link(v::l::top "v::l::ip2 <= 3.10.1")
+
+    ip_link(v::l::top "v::l::ip2 >= 2.9.3")
+    ip_link(v::l::top "v::l::ip2 >  2.9.2")
+    ip_link(v::l::top "v::l::ip2 >  2.9.2")
+    ip_link(v::l::top "v::l::ip2 <  4.9.2")
+    ip_link(v::l::top "v::l::ip2 <= 4.9.2")
+    ip_link(v::l::top "v::l::ip2 <= 4.9.1")
+endfunction()
+
+
+set(TEST_NAME ip_link_version_condition_mult_0)
+
+ct_add_test(NAME ${TEST_NAME})
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+
+    ip_link(v::l::top "v::l::ip2 >= 3.9.2, < 4.0.0")
+    ip_link(v::l::top "v::l::ip2 < 3.9.3, > 3.9.1")
+    ip_link(v::l::top "v::l::ip2 == 3.9.2, < 3.20.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_mult_1)
+
+ct_add_test(NAME ${TEST_NAME})
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    add_ip(v::l::ip3::4.40.100)
+    add_ip(v::l::ip4::100.120.5)
+
+
+    ip_link(v::l::top
+            "v::l::ip2 >=3.9.0, <= 3.9.5"
+            "v::l::ip3 >= 4.0.100, < 4.100.0"
+            "v::l::ip4 < 200.200.200, > 100.100.100"
+        )
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_gteq_fail_0)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 >= 3.9.3")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_gteq_fail_1)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 >= 3.10.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_gteq_fail_2)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 >= 4.9.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_gt_fail_0)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 > 3.9.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_gt_fail_1)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 > 3.10.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_gt_fail_2)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 > 4.9.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_lt_fail_0)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 < 3.9.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_lt_fail_1)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 < 3.8.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_lt_fail_2)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 < 2.9.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_lteq_fail_0)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 <= 3.9.1")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_lteq_fail_1)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 <= 3.8.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_lteq_fail_2)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 <= 2.9.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_eq_fail_0)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 == 3.9.1")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_eq_fail_1)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 == 3.8.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_eq_fail_2)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 == 2.9.2")
+endfunction()
+
+set(TEST_NAME ip_link_version_condition_mult_fail_0)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 > 2.9.2, < 3.9.2")
+endfunction()
+
+
+set(TEST_NAME ip_link_version_condition_mult_fail_1)
+ct_add_test(NAME ${TEST_NAME} EXPECTFAIL)
+function(${${TEST_NAME}})
+    add_ip(v::l::top::1.5.1)
+    add_ip(v::l::ip2::3.9.2)
+    ip_link(v::l::top "v::l::ip2 > 3.9.2, < 4.9.2")
+endfunction()


### PR DESCRIPTION
This pull request enables specifying a range of versions that are allowed in `ip_link()` call.
This can be useful to ensure that the correct version of dependent IP is used to avoid issues.

It is now possible to specify the version ranges as following:


```
add_ip(v::l::top)
add_ip(v::l::ip2::3.9.2)

ip_link(v::l::top 
    "v::l::ip2 >= 3.9.2, < 4.0.0"
)
```

Supported relational operators are >, <, >=, <= and ==.
The conditions are separated by a , (comma) symbol.
All the conditions need to be satisfied for the link, otherwise `FATAL_ERROR` is issued.

Let me know what you think of this feature.