### PR TITLE
Cocotb update

### DIFF
--- a/cmake/sim/cocotb/cocotb.cmake
+++ b/cmake/sim/cocotb/cocotb.cmake
@@ -70,9 +70,9 @@ function(cocotb IP_LIB)
         message(FATAL_ERROR "Cocotb not found. Please install it or provide the path to the cocotb-config executable.")
     endif()
     execute_process(
-        OUTPUT_VARIABLE COCOTB_PY_DIR
+        OUTPUT_VARIABLE COCOTB_SHARE_DIR
         ERROR_VARIABLE ERROR_MSG
-        COMMAND ${COCOTB_CONFIG_EXECUTABLE} --prefix
+        COMMAND ${COCOTB_CONFIG_EXECUTABLE} --share
     )
     execute_process(
         OUTPUT_VARIABLE COCOTB_LIB_DIR
@@ -80,11 +80,10 @@ function(cocotb IP_LIB)
         COMMAND ${COCOTB_CONFIG_EXECUTABLE} --lib-dir
     )
     # Remove the line feed of the variable
-    string(STRIP ${COCOTB_PY_DIR} COCOTB_PY_DIR)
+    string(STRIP ${COCOTB_SHARE_DIR} COCOTB_SHARE_DIR)
     string(STRIP ${COCOTB_LIB_DIR} COCOTB_LIB_DIR)
-    set(COCOTB_SHARE_DIR ${COCOTB_PY_DIR}/cocotb/share)
     # First get all Python files from cocotb
-    file(GLOB_RECURSE COCOTB_PY_DEPS ${COCOTB_PY_DIR}/*.py)
+    file(GLOB_RECURSE COCOTB_PY_DEPS ${COCOTB_SHARE_DIR}/../*.py)
     # Get all files in the cocotb library directory
     file(GLOB COCOTB_LIB_DEPS ${COCOTB_LIB_DIR}/*.so)
 

--- a/cmake/sim/iverilog/iverilog.cmake
+++ b/cmake/sim/iverilog/iverilog.cmake
@@ -26,7 +26,7 @@ include_guard(GLOBAL)
 # ]]]
 function(iverilog IP_LIB)
     # Parse the function arguments
-    cmake_parse_arguments(ARG "NO_RUN_TARGET" "TOP_MODULE;OUTDIR;EXECUTABLE;RUN_TARGET_NAME" "IVERILOG_ARGS;RUN_ARGS;FILE_SETS" ${ARGN})
+    cmake_parse_arguments(ARG "NO_RUN_TARGET" "TOP_MODULE;OUTDIR;EXECUTABLE;RUN_TARGET_NAME" "SV_COMPILE_ARGS;RUN_ARGS;FILE_SETS" ${ARGN})
     # Check for any unrecognized arguments
     if(ARG_UNPARSED_ARGUMENTS)
         message(FATAL_ERROR "${CMAKE_CURRENT_FUNCTION} passed unrecognized argument " "${ARG_UNPARSED_ARGUMENTS}")

--- a/examples/simple_cocotb/CMakeLists.txt
+++ b/examples/simple_cocotb/CMakeLists.txt
@@ -5,6 +5,9 @@ include("../../SoCMakeConfig.cmake")
 
 option_enum(SIMULATOR "Which simulator to use" "iverilog;xcelium;verilator;vcs" "iverilog")
 
+# Support of Verilator is limited with cocotb 
+# Cocotb 1.8.1 and verilator 5.012 works together, that's why we build this exact version
+# If verilator does not work with cocotb on your machine, it's recommended to use an other tool
 if(${SIMULATOR} STREQUAL "verilator")
     verilator_build(VERSION 5.012 EXACT_VERSION)
 endif()


### PR DESCRIPTION
Small fix/improvements have been done to Cocotb:
 - The examples are now working with Verilator and Iverilog.
 - I have changed how we get different path and files, this way, SoCMake can now **theoretically** support Cocotb 2.+, without breaking the support with Cocotb 1.8.1 (and most version)
 - When running Cocotb script of the example with Iverilog, it was not passing the argument parsing, due to unchanged ARGS. I tried to change everything to have a clean `iverilog.cmake` using `IVERILOG_ARGS` instead of `SV_COMPILE_ARGS` but it didn't work has the arguments were not given at the end. So I changed it back to `SV_COMPILE_ARGS` and now everything works
 - About Verilator, it's one of the less supported simulation tool by Cocotb, the current configuration is working (Cocotb 1.8.1 and Verilator 15.012 using the build script). I have tried to make it run with other versions, but it easily becomes a mess...
 
 Maybe we could also discuss if, in the future, we want to fully support Cocotb2.+ and with or without Verilator.