### PR TITLE
Add custom target to run some examples in a single command

### DIFF
--- a/examples/dpi-c/CMakeLists.txt
+++ b/examples/dpi-c/CMakeLists.txt
@@ -55,6 +55,8 @@ if(SIMULATOR STREQUAL "verilator")
     verilator(${IP})
     add_executable(verilator_tb EXCLUDE_FROM_ALL Vtb__main.cpp )
     target_link_libraries(verilator_tb tb__vlt)
+    add_custom_target(run_tb_verilator
+        COMMAND verilator_tb)
 endif()
 
 help()

--- a/examples/simple_mixed_language_sc_vlog/CMakeLists.txt
+++ b/examples/simple_mixed_language_sc_vlog/CMakeLists.txt
@@ -5,14 +5,14 @@ set(FETCHCONTENT_BASE_DIR ${CMAKE_CURRENT_LIST_DIR}/deps/_deps)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 set(SOCMAKE_ADDITIONAL_LANGUAGES SYSTEMC)
 
-option_enum(SIMULATOR "Which Simulator to use" "mgc;osci;xcelium;vcs" "vcs")
+option_enum(SIMULATOR "Which Simulator to use" "modelsim;osci;xcelium;vcs" "vcs")
 option_enum(TEST_LANG "Language for test module" "verilog;systemc" "verilog")
 option_enum(DUT_LANG "Language for DUT modules" "verilog;systemc" "verilog")
 option_boolean(MGC_GUI "Use GUI for modelsim" OFF)
 
 if(SIMULATOR STREQUAL "xcelium")
     xcelium_configure_cxx(LIBRARIES SystemC)
-elseif(SIMULATOR STREQUAL "mgc")
+elseif(SIMULATOR STREQUAL "modelsim")
     modelsim_configure_cxx(LIBRARIES SystemC)
 elseif(SIMULATOR STREQUAL "vcs")
     vcs_configure_cxx(LIBRARIES SystemC)
@@ -55,7 +55,7 @@ endif()
 # ################ MODELSIM ######################
 # ################################################
 
-if(SIMULATOR STREQUAL "mgc")
+if(SIMULATOR STREQUAL "modelsim")
     if(MGC_GUI)
         set(modelsim_gui_args GUI)
         set(modelsim_gui_run_args -vopt -voptargs=+acc=pn)

--- a/examples/simple_sc_sv/CMakeLists.txt
+++ b/examples/simple_sc_sv/CMakeLists.txt
@@ -34,5 +34,8 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
     VERBOSE
     )
 
+add_custom_target(run_simple_sc_sv_example
+    COMMAND simple_sc_sv_example)
+
 help()
 

--- a/examples/systemc/CMakeLists.txt
+++ b/examples/systemc/CMakeLists.txt
@@ -13,3 +13,7 @@ add_executable(systemc_example
 
 target_link_libraries(systemc_example PUBLIC
     SystemC::systemc)
+
+add_custom_target(run_systemc_example
+    COMMAND systemc_example)
+    

--- a/examples/systemc/CMakeLists.txt
+++ b/examples/systemc/CMakeLists.txt
@@ -16,4 +16,3 @@ target_link_libraries(systemc_example PUBLIC
 
 add_custom_target(run_systemc_example
     COMMAND systemc_example)
-    

--- a/examples/uvm-systemc/CMakeLists.txt
+++ b/examples/uvm-systemc/CMakeLists.txt
@@ -18,3 +18,6 @@ target_include_directories(systemc_example PUBLIC
 target_link_libraries(systemc_example PUBLIC
     SystemC::systemc
     UVM-SystemC::shared)
+
+add_custom_target(run_systemc_example
+    COMMAND systemc_example)

--- a/examples/verilator/CMakeLists.txt
+++ b/examples/verilator/CMakeLists.txt
@@ -13,4 +13,7 @@ add_executable(testbench main.cpp)
 
 target_link_libraries(testbench adder::vlt)
 
+add_custom_target(run_tb_verilator
+    COMMAND testbench)
+
 help()


### PR DESCRIPTION
By using `add_custom_target()` cmake function, we are able to create a target `run_executable`.
CMake will generate the right Makefiles, allowing to use this new target, that will do everything needed to compile the executable and then run it.

Before adding this custom target, we were only able to compile the executable correctly and the executable had to be launched manually.

This would be helpful to improve the CI.