### PR TITLE
Bootstrap scripts for SoCMake

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,22 @@ Getting started
 SoCMake is lightweight and has minimal dependencies.
 The only mandatory dependencies are `CMake>=3.25.0` and `make` ([Install Dependencies](https://hep-soc.github.io/SoCMake/docs/getting_started))
 
-There is no need to install SoCMake on your system, it is possible to fetch it in your `CMakeLists.txt`
+### One-Time Bootstrap Installation (Recommended)
 
-Create a file called `CMakeLists.txt`
+Install the SoCMake bootstrap files once on your system:
+**TODO Change the repo and branch name after merging**
+```bash
+curl -fsSL https://raw.githubusercontent.com/risto97/socmake/bootstrap/bootstrap/bootstrap.sh | sh
+```
+
+This installs lightweight bootstrap files to `~/.local/lib/cmake/socmake` that automatically fetch the correct SoCMake version for each project.
+In order to use it create a file called `CMakeLists.txt`
 
 ```CMake
-# Bootstrap SoCMake into CMake project
-include(FetchContent)
-FetchContent_Declare(SoCMake
-    GIT_REPOSITORY "https://github.com/HEP-SoC/SoCMake.git"
-    GIT_TAG develop)
-FetchContent_MakeAvailable(SoCMake)
-
 cmake_minimum_required(VERSION 3.25) # CMake minimum required version
 project(adder NONE)                  # Name of CMake project
+
+find_package(socmake REQUIRED)
 
 # Create an IP block called adder
 add_ip(adder)  

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e
 
-SOCMAKE_VERSION="${SOCMAKE_VERSION:-develop}"
+# TODO We should fix this to a tag that we know contains these scripts
+# These scripts should not change in the future, as there is no version information
+SOCMAKE_VERSION="${SOCMAKE_VERSION:-bootstrap}"
 INSTALL_DIR="${HOME}/.local/lib/cmake/socmake"
 # TODO change this once merged to main repo
 REPO_URL="${SOCMAKE_REPO_URL:-https://raw.githubusercontent.com/risto97/socmake}"

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+SOCMAKE_VERSION="${SOCMAKE_VERSION:-develop}"
+INSTALL_DIR="${HOME}/.local/lib/cmake/socmake"
+# TODO change this once merged to main repo
+REPO_URL="${SOCMAKE_REPO_URL:-https://raw.githubusercontent.com/risto97/socmake}"
+
+echo "Installing SoCmake bootstrap files..."
+echo "  Git tag: ${SOCMAKE_VERSION}"
+echo "  Install directory: ${INSTALL_DIR}"
+echo "  Repository: ${REPO_URL}"
+
+# Create installation directory
+mkdir -p "${INSTALL_DIR}"
+
+# Download bootstrap files
+echo "Downloading bootstrap files..."
+curl -fsSL "${REPO_URL}/${SOCMAKE_VERSION}/bootstrap/socmake-config.cmake" \
+  -o "${INSTALL_DIR}/socmake-config.cmake"
+
+curl -fsSL "${REPO_URL}/${SOCMAKE_VERSION}/bootstrap/socmake-config-version.cmake" \
+  -o "${INSTALL_DIR}/socmake-config-version.cmake"
+
+echo "✓ SoCmake bootstrap installed successfully! in ${INSTALL_DIR}"
+echo ""
+echo "To use in your CMakeLists.txt add the following:"
+echo "  find_package(socmake)"

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -2,9 +2,10 @@
 set -e
 
 # Configuration
-SOCMAKE_VERSION="${SOCMAKE_VERSION:-bootstrap}"
+# TODO change develop to a fixed TAG
+SOCMAKE_VERSION="${SOCMAKE_VERSION:-develop}"
 INSTALL_DIR="${HOME}/.local/lib/cmake/socmake"
-REPO_URL="${SOCMAKE_REPO_URL:-https://raw.githubusercontent.com/risto97/socmake}"
+REPO_URL="${SOCMAKE_REPO_URL:-https://raw.githubusercontent.com/HEP-SoC/SoCMake}"
 
 echo "Installing SoCMake bootstrap files..."
 echo "  Git tag: ${SOCMAKE_VERSION}"

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -1,11 +1,9 @@
 #!/bin/sh
 set -e
 
-# TODO We should fix this to a tag that we know contains these scripts
-# These scripts should not change in the future, as there is no version information
+# Configuration
 SOCMAKE_VERSION="${SOCMAKE_VERSION:-bootstrap}"
 INSTALL_DIR="${HOME}/.local/lib/cmake/socmake"
-# TODO change this once merged to main repo
 REPO_URL="${SOCMAKE_REPO_URL:-https://raw.githubusercontent.com/risto97/socmake}"
 
 echo "Installing SoCMake bootstrap files..."
@@ -17,14 +15,32 @@ echo "  Repository: ${REPO_URL}"
 mkdir -p "${INSTALL_DIR}"
 
 # Download bootstrap files
-echo "Downloding bootstrap files..."
+echo "Downloading bootstrap files..."
 curl -fsSL "${REPO_URL}/${SOCMAKE_VERSION}/bootstrap/socmake-config.cmake" \
   -o "${INSTALL_DIR}/socmake-config.cmake"
 
 curl -fsSL "${REPO_URL}/${SOCMAKE_VERSION}/bootstrap/socmake-config-version.cmake" \
   -o "${INSTALL_DIR}/socmake-config-version.cmake"
 
-echo "✓ SoCMake bootstrap installed successfully! in ${INSTALL_DIR}"
+echo "✓ SoCMake bootstrap installed successfully in ${INSTALL_DIR}"
 echo ""
-echo "To use in your CMakeLists.txt add the following:"
+echo "----------------------------------------------------------------"
+echo "                       Final STEPS                              "
+echo "----------------------------------------------------------------"
+echo "To allow CMake to find 'SoCMake', please add the following block"
+echo "to your shell configuration file (e.g., ~/.bashrc or ~/.zshrc):"
+echo ""
+echo "\`\`\`"
+echo "if [[ \":\$CMAKE_PREFIX_PATH:\" != *\":\$HOME/.local/lib/cmake:\"* ]]; then"
+echo "    export CMAKE_PREFIX_PATH=\"\$HOME/.local/lib/cmake:\$CMAKE_PREFIX_PATH\""
+echo "fi"
+echo "\`\`\`"
+echo ""
+echo "Then, restart your terminal or run 'source ~/.bashrc'."
+echo ""
+echo "----------------------------------------------------------------"
+echo ""
+echo "To use SoCMake in your CMakeLists.txt add the following:"
 echo "  find_package(socmake)"
+echo ""
+echo "----------------------------------------------------------------"

--- a/bootstrap/bootstrap.sh
+++ b/bootstrap/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 # TODO We should fix this to a tag that we know contains these scripts
@@ -8,7 +8,7 @@ INSTALL_DIR="${HOME}/.local/lib/cmake/socmake"
 # TODO change this once merged to main repo
 REPO_URL="${SOCMAKE_REPO_URL:-https://raw.githubusercontent.com/risto97/socmake}"
 
-echo "Installing SoCmake bootstrap files..."
+echo "Installing SoCMake bootstrap files..."
 echo "  Git tag: ${SOCMAKE_VERSION}"
 echo "  Install directory: ${INSTALL_DIR}"
 echo "  Repository: ${REPO_URL}"
@@ -17,14 +17,14 @@ echo "  Repository: ${REPO_URL}"
 mkdir -p "${INSTALL_DIR}"
 
 # Download bootstrap files
-echo "Downloading bootstrap files..."
+echo "Downloding bootstrap files..."
 curl -fsSL "${REPO_URL}/${SOCMAKE_VERSION}/bootstrap/socmake-config.cmake" \
   -o "${INSTALL_DIR}/socmake-config.cmake"
 
 curl -fsSL "${REPO_URL}/${SOCMAKE_VERSION}/bootstrap/socmake-config-version.cmake" \
   -o "${INSTALL_DIR}/socmake-config-version.cmake"
 
-echo "✓ SoCmake bootstrap installed successfully! in ${INSTALL_DIR}"
+echo "✓ SoCMake bootstrap installed successfully! in ${INSTALL_DIR}"
 echo ""
 echo "To use in your CMakeLists.txt add the following:"
 echo "  find_package(socmake)"

--- a/bootstrap/socmake-config-version.cmake
+++ b/bootstrap/socmake-config-version.cmake
@@ -1,0 +1,16 @@
+# Since SoCMake is just a fetcher, any version is compatible
+set(PACKAGE_VERSION_COMPATIBLE TRUE)
+set(PACKAGE_VERSION_EXACT FALSE)
+
+# If a specific version was requested, check if we can provide it
+if(PACKAGE_FIND_VERSION)
+    # We always fetch the exact version requested, so we're always compatible
+    set(PACKAGE_VERSION "${PACKAGE_FIND_VERSION}")
+    set(PACKAGE_VERSION_EXACT TRUE)
+else()
+    # No version requested, we're compatible
+    set(PACKAGE_VERSION "0.0.0")
+endif()
+
+# We support all versions since we fetch on-demand
+set(PACKAGE_VERSION_UNSUITABLE FALSE)

--- a/bootstrap/socmake-config.cmake
+++ b/bootstrap/socmake-config.cmake
@@ -1,0 +1,32 @@
+set(_socmake_version "${SoCMake_FIND_VERSION}")
+set(_socmake_git_ref "develop")
+set(_socmake_git_url "https://github.com/HEP-SoC/SoCMake.git")
+
+if(_socmake_version)
+    # If version is passed in find_package() call, use it as tag v<VERSION> (prepended v)
+    set(_socmake_git_ref "v${_socmake_version}")
+elseif(DEFINED SoCMake_GIT_TAG)
+    # Allow custom variable for tag/branch/commit
+    set(_socmake_git_ref "${SoCMake_GIT_TAG}")
+endif()
+
+# Git url can be changed with SOCMAKE_GIT_URL variable
+if(SOCMAKE_GIT_URL)
+    set(_socmake_git_url "${SOCMAKE_GIT_URL}")
+endif()
+
+# Don't populate -subbuild to save time during configuration
+# This is introduced in 3.30, but this way we dont need to have 3.30 as minimum version to use the new behavior
+set(CMAKE_POLICY_DEFAULT_CMP0168 NEW)
+
+include(FetchContent)
+FetchContent_Declare(SoCMake
+    GIT_REPOSITORY ${_socmake_git_url}
+    GIT_TAG ${_socmake_git_ref}
+)
+FetchContent_MakeAvailable(SoCMake)
+
+set(SoCMake_FOUND TRUE)
+set(SoCMake_VERSION ${SoCMake_FIND_VERSION})
+# Override the variable that find_package() sets to point to the fetched repo instead of the one in .local/lib/cmake
+set(SoCMake_DIR "${SoCMake_SOURCE_DIR}" CACHE STRING "SoCMake package dir" FORCE)

--- a/bootstrap/socmake-config.cmake
+++ b/bootstrap/socmake-config.cmake
@@ -27,7 +27,7 @@ FetchContent_Declare(${CMAKE_FIND_PACKAGE_NAME}
 FetchContent_MakeAvailable(SoCMake)
 
 set(${CMAKE_FIND_PACKAGE_NAME}_FOUND TRUE)
-set(${CMAKE_FIND_PACKAGE_NAME}_VERSION ${${CMAKE_FIND_PACKAGE_NAME}_FIND_VERSION})
+set(${CMAKE_FIND_PACKAGE_NAME}_VERSION ${SOCMAKE_VERSION})
 
 # Override the variable that find_package() sets to point to the fetched repo instead of the one in .local/lib/cmake
 set(${CMAKE_FIND_PACKAGE_NAME}_DIR "${socmake_SOURCE_DIR}" CACHE STRING "SoCMake package dir" FORCE)

--- a/bootstrap/socmake-config.cmake
+++ b/bootstrap/socmake-config.cmake
@@ -1,17 +1,17 @@
-set(_socmake_version "${SoCMake_FIND_VERSION}")
+set(_socmake_version "${${CMAKE_FIND_PACKAGE_NAME}_FIND_VERSION}")
 set(_socmake_git_ref "develop")
 set(_socmake_git_url "https://github.com/HEP-SoC/SoCMake.git")
 
 if(_socmake_version)
     # If version is passed in find_package() call, use it as tag v<VERSION> (prepended v)
     set(_socmake_git_ref "v${_socmake_version}")
-elseif(DEFINED SoCMake_GIT_TAG)
+elseif(DEFINED SOCMAKE_GIT_TAG)
     # Allow custom variable for tag/branch/commit
-    set(_socmake_git_ref "${SoCMake_GIT_TAG}")
+    set(_socmake_git_ref "${SOCMAKE_GIT_TAG}")
 endif()
 
 # Git url can be changed with SOCMAKE_GIT_URL variable
-if(SOCMAKE_GIT_URL)
+if(DEFINED SOCMAKE_GIT_URL)
     set(_socmake_git_url "${SOCMAKE_GIT_URL}")
 endif()
 
@@ -20,13 +20,14 @@ endif()
 set(CMAKE_POLICY_DEFAULT_CMP0168 NEW)
 
 include(FetchContent)
-FetchContent_Declare(SoCMake
+FetchContent_Declare(${CMAKE_FIND_PACKAGE_NAME}
     GIT_REPOSITORY ${_socmake_git_url}
     GIT_TAG ${_socmake_git_ref}
 )
 FetchContent_MakeAvailable(SoCMake)
 
-set(SoCMake_FOUND TRUE)
-set(SoCMake_VERSION ${SoCMake_FIND_VERSION})
+set(${CMAKE_FIND_PACKAGE_NAME}_FOUND TRUE)
+set(${CMAKE_FIND_PACKAGE_NAME}_VERSION ${${CMAKE_FIND_PACKAGE_NAME}_FIND_VERSION})
+
 # Override the variable that find_package() sets to point to the fetched repo instead of the one in .local/lib/cmake
-set(SoCMake_DIR "${SoCMake_SOURCE_DIR}" CACHE STRING "SoCMake package dir" FORCE)
+set(${CMAKE_FIND_PACKAGE_NAME}_DIR "${socmake_SOURCE_DIR}" CACHE STRING "SoCMake package dir" FORCE)


### PR DESCRIPTION
Here is the solution to #173 .

A bootstrapping script is added to make fetching SoCMake easier.
The bootstrapping script allows for SoCMake to be fetched in the project like so:

```cmake
cmake_minimum_required(VERSION 3.30)
project(find_socmake NONE)

# set(SOCMAKE_GIT_TAG b4f050d)
# set(SOCMAKE_GIT_URL ssh://corporate_git_repo/project/SoCMake.git)
find_package(socmake 0.3.1 EXACT REQUIRED)

add_ip(tb)
```

This form should work both in cases when bootstrapping script is used, or if a system-wide SoCMake installation (Nixpkg) is used (as proposed by @adrianf0 #140 ) .

User needs to run once the following command:
```bash
curl -fsSL https://raw.githubusercontent.com/risto97/socmake/bootstrap/bootstrap/bootstrap.sh | sh
```

This will install 2 files in `~/.local/lib/cmake/socmake`: `socmake-config.cmake` and ` socmake-config-version.cmake`.

These 2 files make a CMake package that the `find_package()` call can find, and its placed in a standard location where CMake searches for packages, without having to add any environment variables.
Also these files are version agnostic, so they should not change with SoCMake updates, what they do is simply forward the `find_package()` call to `FetchContent` instead.
The real repository is cloned into the `FETCHCONTENT_BASE_DIR`, and included into the project.

-----------------

There are 2 variables that influence the bootstrap CMake package.

* `SOCMAKE_GIT_TAG` can be used to specify a commit hash or a branch name, while passing version to `find_package()` can be used only if the version is in SEMVER format, due to how `find_package()` works.
* `SOCMAKE_GIT_URL` in order to specify an alternative repository to download.

In case `find_package(socmake)` is called without version argument, the `develop` branch will be cloned.

----------------

I propose releasing these bootstrap scripts under `MIT` license, so that users can modify the default git url to match their git server.

@mtravaillard , @benoitdenkinger Let me know what you think of this solution.
Should we keep in the readme the `FetchContent` instructions, or just add a link to the website documentation on how to use `CPM`, `FetchContent` or `Nix` (in the future) as additional ways of fetching it? 
