### PR TITLE
Fix #175

### DIFF
--- a/examples/simple_sc_sv/CMakeLists.txt
+++ b/examples/simple_sc_sv/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.25)
 project(simple_sc_sv_example C CXX)
 
+# Verilator with SystemC requires C++17
+set(CMAKE_CXX_STANDARD 17)
+
 # Include SoCMake build system
 include("../../SoCMakeConfig.cmake")
 


### PR DESCRIPTION
Fixing issue #175 by setting the C++ standard to C++17, which is needed when using systemc and verilator together.
Depending on the compiler used, C++17 might not be the default standard.