### PR TITLE
fix #171 : Remove policy CMP0144

### DIFF
--- a/cmake/sim/verilator/verilator.cmake
+++ b/cmake/sim/verilator/verilator.cmake
@@ -38,14 +38,10 @@ function(verilator IP_LIB)
     ## Find verilator installation ###
     ##################################
     if(NOT VERILATOR_HOME)
-        # Ensure CMP0144 is set before find_package to get rid of warning
-        cmake_policy(PUSH)
-        cmake_policy(SET CMP0144 NEW)
         find_package(verilator REQUIRED
             HINTS ${VERISC_HOME}/open/* $ENV{VERISC_HOME}/open/*
             )
         set(VERILATOR_HOME "${verilator_DIR}/../../")
-        cmake_policy(POP)
     endif()
 
     find_file(_VERILATED_H verilated.h REQUIRED

--- a/cmake/sim/verilator/verilator/CMakeLists.txt
+++ b/cmake/sim/verilator/verilator/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.25)
-cmake_policy(SET CMP0144 NEW)
 
 project(${TARGET})
 


### PR DESCRIPTION
Policy CMP0144 was still set and was not needed anymore, since `BUILD_JOB_SERVER_AWARE` has been removed on the develop branch.
This way we are still compatible with cmake 3.25 as a minimum version and solving a cmake version issue that was not necessary anymore.