### PR TITLE
Bump minimal CMake version to 3.27 and keep policy CMP0144

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 
 # Version is set first to reuse it across the SoCMake project
 # For example, docs/CMakeLists.txt includes this file to retrieve the version

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Getting started
 ---------------
 
 SoCMake is lightweight and has minimal dependencies.
-The only mandatory dependencies are `CMake>=3.27.0` and `make` ([Install Dependencies](https://hep-soc.github.io/SoCMake/docs/getting_started))
+The only mandatory dependencies are `CMake>=3.25.0` and `make` ([Install Dependencies](https://hep-soc.github.io/SoCMake/docs/getting_started))
 
 ### One-Time Bootstrap Installation (Recommended)
 
@@ -49,7 +49,7 @@ This installs lightweight bootstrap files to `~/.local/lib/cmake/socmake` that a
 In order to use it create a file called `CMakeLists.txt`
 
 ```CMake
-cmake_minimum_required(VERSION 3.27) # CMake minimum required version
+cmake_minimum_required(VERSION 3.25) # CMake minimum required version
 project(adder NONE)                  # Name of CMake project
 
 find_package(socmake REQUIRED)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Getting started
 ---------------
 
 SoCMake is lightweight and has minimal dependencies.
-The only mandatory dependencies are `CMake>=3.25.0` and `make` ([Install Dependencies](https://hep-soc.github.io/SoCMake/docs/getting_started))
+The only mandatory dependencies are `CMake>=3.27.0` and `make` ([Install Dependencies](https://hep-soc.github.io/SoCMake/docs/getting_started))
 
 ### One-Time Bootstrap Installation (Recommended)
 
@@ -49,7 +49,7 @@ This installs lightweight bootstrap files to `~/.local/lib/cmake/socmake` that a
 In order to use it create a file called `CMakeLists.txt`
 
 ```CMake
-cmake_minimum_required(VERSION 3.25) # CMake minimum required version
+cmake_minimum_required(VERSION 3.27) # CMake minimum required version
 project(adder NONE)                  # Name of CMake project
 
 find_package(socmake REQUIRED)

--- a/SoCMakeConfig.cmake
+++ b/SoCMakeConfig.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 
 set(SoCMake_FOUND TRUE)
 

--- a/cmake/build_scripts/systemc/CMakeLists.txt
+++ b/cmake/build_scripts/systemc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(systemc_build)
 
 include("../../utils/option.cmake")

--- a/cmake/build_scripts/uvm-systemc/CMakeLists.txt
+++ b/cmake/build_scripts/uvm-systemc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(uvm-systemc_build)
 
 include("../../utils/option.cmake")

--- a/cmake/build_scripts/verilator/CMakeLists.txt
+++ b/cmake/build_scripts/verilator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(verilator_build)
 
 include("../../utils/option.cmake")

--- a/cmake/sim/verilator/verilator/CMakeLists.txt
+++ b/cmake/sim/verilator/verilator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 cmake_policy(SET CMP0144 NEW)
 
 project(${TARGET})

--- a/cmake/sim/verisc/CMakeLists.txt
+++ b/cmake/sim/verisc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(verisc)
 
 set(DEPS "SYSTEMC;UVM-SYSTEMC;VERILATOR;FC4SC;ICSC_COMPILER;GCC")

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 
 # This adds the top CMakeLists.txt file to retrieve information
 # like the version of SoCMake.

--- a/docs/docs/getting_started.mdx
+++ b/docs/docs/getting_started.mdx
@@ -8,7 +8,7 @@ The SoCMake source code is available on the following [link](https://gitlab.cern
 
 ## Dependencies
 
-Only mandatory SoCMake dependencies are `CMake>=3.27.0` and `make`.
+Only mandatory SoCMake dependencies are `CMake>=3.25.0` and `make`.
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="PIP">
 ```
 ```bash
-pip install cmake==3.28.6
+pip install cmake==3.26.3
 ```
 
 ```mdx-code-block
@@ -26,9 +26,9 @@ pip install cmake==3.28.6
 <TabItem value="WGET">
 ```
 ```bash
-wget https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-linux-x86_64.sh
-chmod +x cmake-3.28.6-linux-x86_64.sh
-./cmake-3.28.6-linux-x86_64.sh --skip-license --prefix=$(pwd)/cmake
+wget https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3-linux-x86_64.sh
+chmod +x cmake-3.26.3-linux-x86_64.sh
+./cmake-3.26.3-linux-x86_64.sh --skip-license --prefix=$(pwd)/cmake
 export PATH=$(pwd)/cmake/bin:$PATH
 ```
 
@@ -137,7 +137,7 @@ In the main `CMakeLists.txt` include `deps/deps.cmake`.
 It should look like this:
 
 ```cmake
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.25)
 project(example NONE)
 
 include("deps/deps.cmake")

--- a/docs/docs/getting_started.mdx
+++ b/docs/docs/getting_started.mdx
@@ -8,7 +8,7 @@ The SoCMake source code is available on the following [link](https://gitlab.cern
 
 ## Dependencies
 
-Only mandatory SoCMake dependencies are `CMake>=3.25.0` and `make`.
+Only mandatory SoCMake dependencies are `CMake>=3.27.0` and `make`.
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 <TabItem value="PIP">
 ```
 ```bash
-pip install cmake==3.26.3
+pip install cmake==3.28.6
 ```
 
 ```mdx-code-block
@@ -26,9 +26,9 @@ pip install cmake==3.26.3
 <TabItem value="WGET">
 ```
 ```bash
-wget https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3-linux-x86_64.sh
-chmod +x cmake-3.26.3-linux-x86_64.sh
-./cmake-3.26.3-linux-x86_64.sh --skip-license --prefix=$(pwd)/cmake
+wget https://github.com/Kitware/CMake/releases/download/v3.28.6/cmake-3.28.6-linux-x86_64.sh
+chmod +x cmake-3.28.6-linux-x86_64.sh
+./cmake-3.28.6-linux-x86_64.sh --skip-license --prefix=$(pwd)/cmake
 export PATH=$(pwd)/cmake/bin:$PATH
 ```
 
@@ -137,7 +137,7 @@ In the main `CMakeLists.txt` include `deps/deps.cmake`.
 It should look like this:
 
 ```cmake
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(example NONE)
 
 include("deps/deps.cmake")

--- a/examples/cpm/CMakeLists.txt
+++ b/examples/cpm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(example NONE)
 
 include("deps/deps.cmake")

--- a/examples/dpi-c/CMakeLists.txt
+++ b/examples/dpi-c/CMakeLists.txt
@@ -14,7 +14,7 @@ elseif(SIMULATOR MATCHES "verilator")
     verilator_configure_cxx(LIBRARIES DPI-C)
 endif()
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(dpi_example NONE)
 
 add_ip(tb

--- a/examples/dpi-c/hello/CMakeLists.txt
+++ b/examples/dpi-c/hello/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(hello_dpi CXX)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/examples/fetchcontent/CMakeLists.txt
+++ b/examples/fetchcontent/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(install)
 
 include(FetchContent)

--- a/examples/linking_ips/CMakeLists.txt
+++ b/examples/linking_ips/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(example 
     LANGUAGES NONE
     VERSION 0.0.1)

--- a/examples/options/CMakeLists.txt
+++ b/examples/options/CMakeLists.txt
@@ -3,7 +3,7 @@
 ## To print help message for options run `make help_options`
 ## To see options in gui run `cmake-gui ../`
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(options_example NONE)
 
 include("../../SoCMakeConfig.cmake")

--- a/examples/simple_cocotb/CMakeLists.txt
+++ b/examples/simple_cocotb/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(simple_cocotb_example CXX)
 
 include("../../SoCMakeConfig.cmake")

--- a/examples/simple_mixed_language/CMakeLists.txt
+++ b/examples/simple_mixed_language/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(simple_mixed_language NONE)
 
 include("../../SoCMakeConfig.cmake")

--- a/examples/simple_mixed_language_sc_vlog/CMakeLists.txt
+++ b/examples/simple_mixed_language_sc_vlog/CMakeLists.txt
@@ -25,7 +25,7 @@ else()
     set(CMAKE_CXX_STANDARD 11)
 endif()
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(simple_mixed_language_sc_vlog CXX)
 
 add_subdirectory(tests)

--- a/examples/simple_sc_sv/CMakeLists.txt
+++ b/examples/simple_sc_sv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(simple_sc_sv_example C CXX)
 
 # Verilator with SystemC requires C++17

--- a/examples/simple_verilog/CMakeLists.txt
+++ b/examples/simple_verilog/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(simple_verilog_example CXX C)
 
 include("../../SoCMakeConfig.cmake")

--- a/examples/simple_vhdl/CMakeLists.txt
+++ b/examples/simple_vhdl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(simple_mixed_language NONE)
 
 include("../../SoCMakeConfig.cmake")

--- a/examples/systemc/CMakeLists.txt
+++ b/examples/systemc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(systemc_example CXX)
 
 include("../../SoCMakeConfig.cmake")

--- a/examples/uvm-systemc/CMakeLists.txt
+++ b/examples/uvm-systemc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(uvm-systemc_example CXX C)
 
 include("../../SoCMakeConfig.cmake")

--- a/examples/verilator/CMakeLists.txt
+++ b/examples/verilator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(example CXX C)
 
 include("../../SoCMakeConfig.cmake")

--- a/examples/verilator/adder/CMakeLists.txt
+++ b/examples/verilator/adder/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(adder NONE)
 
 add_ip(adder

--- a/examples/vhpidirect/customc/CMakeLists.txt
+++ b/examples/vhpidirect/customc/CMakeLists.txt
@@ -1,5 +1,5 @@
 include("../../../SoCMakeConfig.cmake")
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(vhpidirect_customc C)
 
 add_ip(tb)

--- a/tests/tests/CMakeLists.txt
+++ b/tests/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(SoCMake_testing)
 
 include(CTest)

--- a/tests/tests/ip_include_directories/ip_include_directories_rel_path/test/CMakeLists.txt
+++ b/tests/tests/ip_include_directories/ip_include_directories_rel_path/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Test relative include directories paths, the behaviour is matching the CMake behaviour of target_include_directories():
 # Changed in version 3.13: Relative source file paths are interpreted as being relative to the current source directory (i.e. CMAKE_CURRENT_SOURCE_DIR). See policy CMP0076.
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(ip_include_directories_rel_path NONE)
 
 include("../../../../../SoCMakeConfig.cmake")

--- a/tests/tests/ip_sources/ip_sources_rel_path/test/CMakeLists.txt
+++ b/tests/tests/ip_sources/ip_sources_rel_path/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Test relative source file paths, the behaviour is matching the CMake behaviour of target_sources:
 # Changed in version 3.13: Relative source file paths are interpreted as being relative to the current source directory (i.e. CMAKE_CURRENT_SOURCE_DIR). See policy CMP0076.
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(ip_sources_rel_path NONE)
 
 include("../../../../../SoCMakeConfig.cmake")

--- a/tests/tests/iverilog/iverilog_multi_top/CMakeLists.txt
+++ b/tests/tests/iverilog/iverilog_multi_top/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(iverilog_multi_top NONE)
 
 add_ip(iverilog_multi_top

--- a/tests/tests/iverilog/iverilog_simple_test/CMakeLists.txt
+++ b/tests/tests/iverilog/iverilog_simple_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(iverilog_simple_test NONE)
 
 add_ip(iverilog_simple_test

--- a/tests/tests/peakrdl/html/CMakeLists.txt
+++ b/tests/tests/peakrdl/html/CMakeLists.txt
@@ -1,7 +1,7 @@
 include("../../../../SoCMakeConfig.cmake")
 include("../../../utils/test_utils.cmake")
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(test NONE)
 
 ### A simple test with default arguments

--- a/tests/tests/peakrdl/print/CMakeLists.txt
+++ b/tests/tests/peakrdl/print/CMakeLists.txt
@@ -1,5 +1,5 @@
 include("../../../../SoCMakeConfig.cmake")
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(peakrdl_print_test NONE)
 
 #########

--- a/tests/tests/peakrdl/regblock/CMakeLists.txt
+++ b/tests/tests/peakrdl/regblock/CMakeLists.txt
@@ -1,7 +1,7 @@
 include("../../../../SoCMakeConfig.cmake")
 include("../../../utils/test_utils.cmake")
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(test NONE)
 
 ### A simple test with default arguments

--- a/tests/tests/vhier/CMakeLists.txt
+++ b/tests/tests/vhier/CMakeLists.txt
@@ -1,6 +1,6 @@
 include("../../../SoCMakeConfig.cmake")
 
-cmake_minimum_required(VERSION 3.25)
+cmake_minimum_required(VERSION 3.27)
 project(vhier_test)
 
 add_subdirectory("ips/mod1")


### PR DESCRIPTION
Final fix for #171 :
 - The policy is kept for the warning that would be caused without it.
 - The minimal CMake version is bumped to 3.27, to support the policy.