### PR TITLE
Add Nix-based Development Environment and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,42 @@ Hello from Adder!
 [100%] Built target run_adder_iverilog
 ```
 
+## Dependency management
+
+Once you use more advanced SoCMake targets, e.g. simulation, etc., you will have dependency on some external tools. You are free to choose how you provide all the dependencies required for your project. However, to simplify this task, a Nix-based workflow is available using the provided `flake.nix` file.
+
+### Using Nix for a Reproducible Environment
+
+Nix allows you to create a fully reproducible development environment with all necessary tools and dependencies pre-installed.
+
+To use the Nix flow:
+
+1. **Install Nix**
+
+Follow the instructions at https://nixos.org/download.html to install the Nix package manager on your system.
+For more advanced Nix installation scenarios, check the guide at [Nix Installation Guide](https://nixos.wiki/wiki/Nix_Installation_Guide#Single-user_install).
+ You can also download a statically linked *nix* binary, useful e.g. in HPC environments: [Static Nix Binary](https://discourse.nixos.org/t/where-can-i-get-a-statically-built-nix/34253/15).
+
+2. **Enter the development environment**
+
+In the project directory (where `flake.nix` is located), run:
+
+```shell
+$ nix --experimental-features 'nix-command flakes' develop
+```
+
+As you can see, we use [Nix flakes](https://nixos.wiki/wiki/Flakes). Nix Flakes can be enabled permanently in the configuration file ([link](https://nixos.wiki/wiki/Flakes)), and then the command is simple:
+
+```shell
+$ nix develop
+```
+
+3. **Start working**
+
+You will be dropped into a shell with all required tools (such as `cmake`, `peakrdl`, `verible`, `verilator`, etc.) available and ready to use.
+
+This approach ensures that everyone working on the project uses the same versions of all dependencies, making builds and development more reliable and reproducible.
+
 Examples
 --------
 

--- a/flake.lock
+++ b/flake.lock
@@ -52,6 +52,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_cmake_3_25": {
+      "locked": {
+        "lastModified": 1704290814,
+        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "peakrdl-socgen": {
       "inputs": {
         "flake-utils": "flake-utils_2",
@@ -78,6 +94,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
+        "nixpkgs_cmake_3_25": "nixpkgs_cmake_3_25",
         "peakrdl-socgen": "peakrdl-socgen"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -76,16 +76,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1773846014,
-        "narHash": "sha256-ZU+UKFGm4tWh0GNKAIcLr+nGg0pf4NHgrtPB7Z4wRBQ=",
+        "lastModified": 1774031463,
+        "narHash": "sha256-nQssNua8JzPRs3cZHX8DVHSO+nQTmf+QtOShZuyl7ss=",
         "owner": "HEP-SoC",
         "repo": "PeakRDL-socgen",
-        "rev": "a1a13b379a280b3adfb206d5ebfbf3ffdcf21b7d",
+        "rev": "9baa6ac91ae72415a98e9ed9e3a3a076d9276a54",
         "type": "github"
       },
       "original": {
         "owner": "HEP-SoC",
-        "ref": "refs/tags/v0.1.6",
+        "ref": "refs/tags/v0.1.7",
         "repo": "PeakRDL-socgen",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,117 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771432645,
+        "narHash": "sha256-ZqRiU5/c+1+QoeaMJJgpqjwimCSNnIl0AUW4z7Md6Ps=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "02263f46911178e286242786fd6ea1d229583fbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "02263f46911178e286242786fd6ea1d229583fbb",
+        "type": "github"
+      }
+    },
+    "peakrdl-socgen": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773846014,
+        "narHash": "sha256-ZU+UKFGm4tWh0GNKAIcLr+nGg0pf4NHgrtPB7Z4wRBQ=",
+        "owner": "HEP-SoC",
+        "repo": "PeakRDL-socgen",
+        "rev": "a1a13b379a280b3adfb206d5ebfbf3ffdcf21b7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "HEP-SoC",
+        "ref": "refs/tags/v0.1.6",
+        "repo": "PeakRDL-socgen",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "peakrdl-socgen": "peakrdl-socgen"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,13 +3,14 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/02263f46911178e286242786fd6ea1d229583fbb";
+    nixpkgs_cmake_3_25.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
 
     peakrdl-socgen.url = "github:HEP-SoC/PeakRDL-socgen?ref=refs/tags/v0.1.6";
     peakrdl-socgen.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, peakrdl-socgen } :
+  outputs = { self, nixpkgs, nixpkgs_cmake_3_25, flake-utils, peakrdl-socgen } :
     flake-utils.lib.eachDefaultSystem (system:
       let
         overlays = [
@@ -27,6 +28,7 @@
         ];
 
         pkgs = import nixpkgs { inherit system overlays; };
+        pkgs_cmake_3_25 = nixpkgs_cmake_3_25.legacyPackages.${system};
         python = pkgs.python3;
 
         pythonDeps = ps: [
@@ -35,7 +37,7 @@
         ];
 
         deps = with pkgs; [
-          cmake
+          pkgs_cmake_3_25.cmake
           gnumake
           sv-lang
           verible

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "SoCMake environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/02263f46911178e286242786fd6ea1d229583fbb";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    peakrdl-socgen.url = "github:HEP-SoC/PeakRDL-socgen?ref=refs/tags/v0.1.6";
+    peakrdl-socgen.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, peakrdl-socgen } :
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        python = pkgs.python3;
+
+        # For 'vhier' tool used by the copy_rtl_files
+        verilogPerl = pkgs.perlPackages.buildPerlPackage (rec {
+          pname = "Verilog-Perl";
+          version = "3.482";
+          src = pkgs.fetchFromGitHub {
+            owner = "veripool";
+            repo = "verilog-perl";
+            rev = "v${version}";
+            hash = "sha256-vpgxzb3DpoIhOZKiw3d6HRwJkpor4dOJBxCY26LKqLA=";
+          };
+          
+          nativeBuildInputs = [pkgs.flex pkgs.bison];
+        });
+
+        pythonDeps = ps: [
+          peakrdl-socgen.packages.${system}.default
+          ps.peakrdl-regblock
+        ];
+
+        deps = with pkgs; [
+          cmake
+          gnumake
+          verible
+          verilator
+          verilogPerl
+        ];
+
+      in {
+        inherit pythonDeps deps;
+
+        devShells.default = pkgs.mkShell {
+          name = "socmake-shell";
+          packages = deps ++ [ (python.withPackages pythonDeps) ];
+          shellHook = ''
+            echo "❄️  SoCMake environment loaded (cmake, verible, verilator, peakrdl)"
+          '';
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     nixpkgs_cmake_3_25.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
 
-    peakrdl-socgen.url = "github:HEP-SoC/PeakRDL-socgen?ref=refs/tags/v0.1.6";
+    peakrdl-socgen.url = "github:HEP-SoC/PeakRDL-socgen?ref=refs/tags/v0.1.7";
     peakrdl-socgen.inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -12,22 +12,22 @@
   outputs = { self, nixpkgs, flake-utils, peakrdl-socgen } :
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs { inherit system; };
-        python = pkgs.python3;
+        overlays = [
+          (self: super: {
+            sv-lang = super.sv-lang.overrideAttrs (old: {
+              version = "10.0";
+              src = super.fetchFromGitHub {
+                owner = "MikePopoloski";
+                repo = "slang";
+                tag = "v10.0";
+                hash = "sha256-rw+DztENuY+DiAhQR2oNN/dQJzrcP5neF3LoWnqri+c=";
+              };
+            });
+          })
+        ];
 
-        # For 'vhier' tool used by the copy_rtl_files
-        verilogPerl = pkgs.perlPackages.buildPerlPackage (rec {
-          pname = "Verilog-Perl";
-          version = "3.482";
-          src = pkgs.fetchFromGitHub {
-            owner = "veripool";
-            repo = "verilog-perl";
-            rev = "v${version}";
-            hash = "sha256-vpgxzb3DpoIhOZKiw3d6HRwJkpor4dOJBxCY26LKqLA=";
-          };
-          
-          nativeBuildInputs = [pkgs.flex pkgs.bison];
-        });
+        pkgs = import nixpkgs { inherit system overlays; };
+        python = pkgs.python3;
 
         pythonDeps = ps: [
           peakrdl-socgen.packages.${system}.default
@@ -37,9 +37,9 @@
         deps = with pkgs; [
           cmake
           gnumake
+          sv-lang
           verible
           verilator
-          verilogPerl
         ];
 
       in {


### PR DESCRIPTION
As we [agree](https://github.com/HEP-SoC/SoCMake/issues/140#issuecomment-3749879885), SoCMake should not take care of installing any software dependencies and should fetch only the project's IPs.

The user is completely free to choose how he/she provides all the dependencies required for the project. However, to simplify this task, this pull request introduces a reproducible development environment for SoCMake using `flake.nix`, and updates the `README.md` with detailed instructions for dependency management.

### Summary of changes

+ Added a `flake.nix` file that defines a Nix development shell with all required tools and dependencies (e.g. `cmake`, `verible`, `verilator`, `peakrdl`, etc.).
+ Updated the `README.md` to include a new section on dependency management, describing how to use the provided `flake.nix` for a consistent and reproducible development environment.

### Additional notes

+ The Nix-based workflow is optional and does not interfere with other ways of managing dependencies.
+ The documentation provides step-by-step instructions and useful links for installing and using Nix.
+ This approach ensures that all contributors can easily set up a consistent development environment, improving reliability and reproducibility.