### PR TITLE
Fix #199 : help directory name clashing with ninja target

### DIFF
--- a/cmake/utils/help/help_utils.cmake
+++ b/cmake/utils/help/help_utils.cmake
@@ -141,7 +141,7 @@ function(help_options)
     string(JSON json_output SET "${json_output}" "options" "${options_array}")
 
     set(target help_options)
-    set(outfile ${CMAKE_BINARY_DIR}/help/${target}.json)
+    set(outfile ${CMAKE_BINARY_DIR}/.help/${target}.json)
     file(WRITE ${outfile} ${json_output})
 
     _create_help_target("options" "option.jq" ${outfile} "*" ${ARG_PRINT_ON_CONF})
@@ -197,7 +197,7 @@ function(help_ips)
     string(JSON json_output SET "${json_output}" "ips" "${ips_array}")
 
     set(target help_ips)
-    set(outfile ${CMAKE_BINARY_DIR}/help/${target}.json)
+    set(outfile ${CMAKE_BINARY_DIR}/.help/${target}.json)
     file(WRITE ${outfile} ${json_output})
 
     _create_help_target("ips" "ip.jq" ${outfile} "*" ${ARG_PRINT_ON_CONF})
@@ -225,7 +225,7 @@ function(help_targets)
 
     # Create the target first, so it can be discovered by get_all_targets() function
     set(target help_targets)
-    set(outfile ${CMAKE_BINARY_DIR}/help/${target}.json)
+    set(outfile ${CMAKE_BINARY_DIR}/.help/${target}.json)
 
     _create_help_target("targets" "target.jq" ${outfile} "*" ${ARG_PRINT_ON_CONF})
 
@@ -316,7 +316,7 @@ function(help_custom_targets GROUP_NAME)
         set(help_name ${GROUP_NAME})
     endif()
 
-    set(outfile ${CMAKE_BINARY_DIR}/help/help_targets.json)
+    set(outfile ${CMAKE_BINARY_DIR}/.help/help_targets.json)
 
     _create_help_target("${help_name}" "target.jq" ${outfile} "${GROUP_NAME}" ${ARG_PRINT_ON_CONF})
 endfunction()
@@ -361,7 +361,7 @@ function(help_custom_ips GROUP_NAME)
 
     group_custom_ips("${GROUP_NAME}" ${ARG_PATTERN} ${ARG_LIST})
 
-    set(outfile ${CMAKE_BINARY_DIR}/help/help_ips.json)
+    set(outfile ${CMAKE_BINARY_DIR}/.help/help_ips.json)
 
     _create_help_target("${GROUP_NAME}" "ip.jq" ${outfile} "${GROUP_NAME}" ${ARG_PRINT_ON_CONF})
 
@@ -407,7 +407,7 @@ function(help_custom_options GROUP_NAME)
 
     group_custom_options("${GROUP_NAME}" ${ARG_PATTERN} ${ARG_LIST})
 
-    set(outfile ${CMAKE_BINARY_DIR}/help/help_options.json)
+    set(outfile ${CMAKE_BINARY_DIR}/.help/help_options.json)
 
     _create_help_target("${GROUP_NAME}" "option.jq" ${outfile} "${GROUP_NAME}" ${ARG_PRINT_ON_CONF})
 

--- a/misc/fzf_socmake.sh
+++ b/misc/fzf_socmake.sh
@@ -38,17 +38,17 @@ __fzf_socmake_target_ip_picker() {
 
 # FZF function for showing IPs
 _fzf_socmake_ips() {
-    __fzf_socmake_target_ip_picker "help/help_ips.json" "Select IP Target" ".ips"
+    __fzf_socmake_target_ip_picker ".help/help_ips.json" "Select IP Target" ".ips"
 }
 
 # FZF function for showing targets
 _fzf_socmake_target() {
-    __fzf_socmake_target_ip_picker "help/help_targets.json" "Select Build Target" ".targets"
+    __fzf_socmake_target_ip_picker ".help/help_targets.json" "Select Build Target" ".targets"
 }
 
 # FZF function for appending cmake options to cmake command
 _fzf_cmake_option_append() {
-    local json_file="help/help_options.json"
+    local json_file=".help/help_options.json"
     if [[ ! -f "$json_file" ]]; then
         echo "Could not find $json_file, verify you are in build directory and the project is configured"
         return

--- a/tests/tests/help/help_targets.cmake
+++ b/tests/tests/help/help_targets.cmake
@@ -254,9 +254,9 @@ function(${${TEST_NAME}})
         endif()
     endfunction()
 
-    set(TARGETS_JSON "${CMAKE_BINARY_DIR}/help/help_targets.json")
-    set(IPS_JSON "${CMAKE_BINARY_DIR}/help/help_ips.json")
-    set(OPTIONS_JSON "${CMAKE_BINARY_DIR}/help/help_options.json")
+    set(TARGETS_JSON "${CMAKE_BINARY_DIR}/.help/help_targets.json")
+    set(IPS_JSON "${CMAKE_BINARY_DIR}/.help/help_ips.json")
+    set(OPTIONS_JSON "${CMAKE_BINARY_DIR}/.help/help_options.json")
 
     # Test that JSON files exist
     if(NOT EXISTS "${TARGETS_JSON}")


### PR DESCRIPTION
Changes the name of the directory to `.help` so it doesn't clash with ninja's target