### PR TITLE
Fix generated IP config file not being found by the find_ip function

### DIFF
--- a/cmake/ipxact/importer/ipxact_ip_importer.cmake
+++ b/cmake/ipxact/importer/ipxact_ip_importer.cmake
@@ -71,4 +71,6 @@ function(add_ip_from_ipxact COMP_XML)
     endif()
     
     set(IP ${IP} PARENT_SCOPE)
+
+    set(${ip_vendor}__${ip_library}__${ip_name}_DIR "${ip_source_dir}" CACHE INTERNAL "" FORCE)
 endfunction()


### PR DESCRIPTION
Fix the problem explained in the issue #200, thanks to @Risto97 [solution](https://github.com/HEP-SoC/SoCMake/issues/200#issuecomment-4216614313)