### PR TITLE
peakrdl_halcpp SKIP_BUSES_ARG and GENERATE_TESTS_ARG fixes

### DIFF
--- a/cmake/peakrdl/peakrdl_halcpp.cmake
+++ b/cmake/peakrdl/peakrdl_halcpp.cmake
@@ -78,11 +78,11 @@ function(peakrdl_halcpp IP_LIB)
     endif()
 
     if(ARG_SKIP_BUSES)
-        set(SKIB_BUSES_ARG --skip-buses)
+        set(SKIP_BUSES_ARG --skip-buses)
     endif()
 
     if(ARG_GENERATE_TESTS)
-        set(ARG_GENERATE_TESTS --generate-tests)
+        set(GENERATE_TESTS_ARG --generate-tests)
     endif()
 
     if(NOT RDL_FILES)
@@ -106,8 +106,8 @@ function(peakrdl_halcpp IP_LIB)
             ${EXT_ARG}
             ${INCDIRS_ARG}
             ${COMPDEFS_ARG}
-            ${ARG_GENERATE_TESTS}
-            ${SKIB_BUSES_ARG} -o ${OUTDIR}
+            ${GENERATE_TESTS_ARG}
+            ${SKIP_BUSES_ARG} -o ${OUTDIR}
             ${OVERWRITTEN_PARAMETERS}
     )
 


### PR DESCRIPTION
- Fix typo in SKIB_BUSES_ARG
- Changed ARG_GENERATE_TESTS -> GENERATE_TESTS_ARG to work when ARG_GENERATE_TESTS is not defined, otherwise FALSE is passed on the command line