### PR TITLE
Re-added VERILATOR_ROOT to verilator external project build phase

### DIFF
--- a/cmake/sim/verilator/verilator.cmake
+++ b/cmake/sim/verilator/verilator.cmake
@@ -245,6 +245,10 @@ function(verilator IP_LIB)
                 ${EXT_PRJ_ARGS}
                 -DVERILATOR_ROOT=${VERILATOR_ROOT}
                 -DSYSTEMC_ROOT=${SYSTEMC_HOME}
+            # VERILATOR_ROOT env variable is required for some older versions of verilator
+            # For the configuration phase, this is set in the verilator/CMakeLists.txt file
+            # For the build phase, this is the simplest (only?) solution
+            BUILD_COMMAND ${CMAKE_COMMAND} -E env VERILATOR_ROOT=${VERILATOR_ROOT} make -j${CMAKE_BUILD_PARALLEL_LEVEL}
             INSTALL_COMMAND ""
             DEPENDS ${IP_LIB}
             EXCLUDE_FROM_ALL 1


### PR DESCRIPTION
Re-added `VERILATOR_ROOT` env variable export when running verilator otherwise the verilator target works only the first time after configuration, then it fails complaining about missing the `VERILATOR_ROOT`variable. The exact reason why it works the first time is not clear.